### PR TITLE
CLI-10725 Buttons should be smaller in the UI for mobile

### DIFF
--- a/CoreScriptsRoot/CoreScripts/ContextActionTouch.lua
+++ b/CoreScriptsRoot/CoreScripts/ContextActionTouch.lua
@@ -103,10 +103,10 @@ function createNewButton(actionName, functionInfoTable)
 	local contextButton = Instance.new("ImageButton")
 	contextButton.Name = "ContextActionButton"
 	contextButton.BackgroundTransparency = 1
-	contextButton.Size = UDim2.new(0,90,0,90)
+	contextButton.Size = UDim2.new(0,45,0,45)
 	contextButton.Active = true
 	if isSmallScreenDevice() then 
-		contextButton.Size = UDim2.new(0,70,0,70)
+		contextButton.Size = UDim2.new(0,35,0,35)
 	end
 	contextButton.Image = ContextUpImage
 	contextButton.Parent = buttonFrame


### PR DESCRIPTION
Made the mobile Jump and context action buttons the same size as the interior thumbstick button (35x35 pixels on small devices, 45,45 on larger ones) and then positioned them accordingly to have roughly the same position on the other side of the screen.